### PR TITLE
Disable XLA usage

### DIFF
--- a/Kraken_XRP_ETH_SOL_AVAX_Trading_Bot_15m_GRU_LSTM_Enhanced.py
+++ b/Kraken_XRP_ETH_SOL_AVAX_Trading_Bot_15m_GRU_LSTM_Enhanced.py
@@ -48,8 +48,8 @@ load_dotenv()
 client = krakenex.API()
 client.load_key('.env')  # ⚠️ Assure-toi que le fichier `kraken.key` existe ou adapte selon ton usage
 
-# Activer XLA pour accélérer les calculs
-tf.config.optimizer.set_jit(True)
+# Désactiver XLA pour une meilleure compatibilité
+tf.config.optimizer.set_jit(False)
 
 # Vérifier les dispositifs physiques disponibles (Metal GPU ou CPU)
 physical_devices = tf.config.list_physical_devices('GPU')
@@ -458,11 +458,10 @@ def create_gru_model(input_shape):
             tf.keras.layers.Dense(1, activation='linear')
         ])
 
-        # Compilation avec XLA activé
+        # Compilation sans XLA
         model.compile(
             optimizer=tf.keras.optimizers.Adam(learning_rate=LEARNING_RATE),
-            loss='mse',
-            jit_compile=True  # Active XLA ici, pas besoin du décorateur @tf.function
+            loss='mse'
         )
 
     return model
@@ -576,7 +575,7 @@ def prepare_last_sequence(returns, volume, volatility, momentum, volume_anomaly)
                                       momentum[-TREND_LOOKBACK:], volume_anomaly[-TREND_LOOKBACK:]))], dtype=np.float32)
 
 
-@tf.function(jit_compile=True)  # Activer XLA pour l'entraînement
+@tf.function  # Entraînement sans XLA
 def train_model(model, X, y):
     # Détecter et choisir device (Metal GPU ou fallback CPU)
     device = "/GPU:0" if tf.config.list_physical_devices('GPU') else "/CPU:0"
@@ -662,7 +661,7 @@ def predict_price_trend(data, symbol):
         live_df['Volume_Anomaly'].values
     )
 
-    @tf.function(jit_compile=True)
+    @tf.function
     def predict_batch():
         return model.predict(last_sequence, verbose=0)
 
@@ -683,7 +682,7 @@ def predict_exit(data, symbol):
                                           live_df['Volatility'].values, live_df['Momentum'].values,
                                           live_df['Volume_Anomaly'].values)
 
-    @tf.function(jit_compile=True)  # Activer XLA pour la prédiction
+    @tf.function  # Prédiction sans XLA
     def predict_batch():
         return gru_models[f'{symbol}_15min'].predict(last_sequence, verbose=0)
 


### PR DESCRIPTION
## Summary
- disable XLA optimizer JIT
- remove `jit_compile=True` from model compilation
- train and predict without XLA

## Testing
- `python -m py_compile Kraken_XRP_ETH_SOL_AVAX_Trading_Bot_15m_GRU_LSTM_Enhanced.py`

------
https://chatgpt.com/codex/tasks/task_e_68458876ffbc832ca5f0086994d0ee65